### PR TITLE
Feature/canon length scaling

### DIFF
--- a/Can/convergence.sc
+++ b/Can/convergence.sc
@@ -1,16 +1,16 @@
 +Can {
-	*converge {|symbol, melody, cp, voices, instruments, player, cycle, repeat = 1, osc, meta|
+	*converge {|symbol, melody, cp, voices, instruments, cycle, player, repeat = 1, osc, meta|
 
     var
 	    makeBcp = {|cp, line| line.copyRange(0, (cp - 2).asInteger)},
 
         makeTempo = {|speed| 60/(speed/4)},
 
-		slowestTempo = voices.collect(_.tempo).minItem.postm("slowestTempo"),
+		slowestTempo = voices.collect(_.tempo).minItem,
 
-		canonLength = melody.collect(_.dur).sum*makeTempo.(slowestTempo),
+		totalDur = melody.collect(_.dur).sum*makeTempo.(slowestTempo),
 
-		scalingFactor = cycle.isNil.if({1}, {cycle/canonLength}),
+		scalingFactor = cycle.isNil.if({1}, {cycle/totalDur}),
 
         //creates voices [(melody: [(note, dur)], bcp)]
         voices1 = (voices

--- a/Can/convergence.sc
+++ b/Can/convergence.sc
@@ -1,5 +1,5 @@
 +Can {
-	*converge {|symbol, melody, cp, voices, instruments, cycle, player, repeat = 1, osc, meta|
+	*converge {|symbol, melody, cp, voices, instruments, period, player, repeat = 1, osc, meta|
 
     var
 	    makeBcp = {|cp, line| line.copyRange(0, (cp - 2).asInteger)},
@@ -10,7 +10,7 @@
 
 		totalDur = melody.collect(_.dur).sum*makeTempo.(slowestTempo),
 
-		scalingFactor = cycle.isNil.if({1}, {cycle/totalDur}),
+		scalingFactor = period.isNil.if({1}, {period/totalDur}),
 
         //creates voices [(melody: [(note, dur)], bcp)]
         voices1 = (voices

--- a/Can/convergence.sc
+++ b/Can/convergence.sc
@@ -1,17 +1,23 @@
 +Can {
-	*converge {|symbol, melody, cp, voices, instruments, player, repeat = 1, osc, meta|
+	*converge {|symbol, melody, cp, voices, instruments, player, cycle, repeat = 1, osc, meta|
 
     var
 	    makeBcp = {|cp, line| line.copyRange(0, (cp - 2).asInteger)},
 
         makeTempo = {|speed| 60/(speed/4)},
 
+		slowestTempo = voices.collect(_.tempo).minItem.postm("slowestTempo"),
+
+		canonLength = melody.collect(_.dur).sum*makeTempo.(slowestTempo),
+
+		scalingFactor = cycle.isNil.if({1}, {cycle/canonLength}),
+
         //creates voices [(melody: [(note, dur)], bcp)]
         voices1 = (voices
             .collect({|voice|
                 //for each melody set the correct durations and transposition
                 melody.collect({|event|
-                    (dur: event.dur*makeTempo.(voice.tempo), note: event.note+voice.transp)
+                    (dur: event.dur*makeTempo.(voice.tempo)*scalingFactor, note: event.note+voice.transp)
                 })
             })
             //get the durations of all notes Before the Convergence Point

--- a/Can/divergence.sc
+++ b/Can/divergence.sc
@@ -1,6 +1,6 @@
 +Can {
 	*prDiverge{
-		|symbol, melody, voices, tempos, baseTempo = 60, instruments, player, repeat, osc, meta, convergeOnLast = false|
+		|symbol, melody, voices, tempos, baseTempo = 60, instruments, cycle, player, repeat, osc, meta, convergeOnLast = false|
 
         var data = (
 			symbol: symbol,
@@ -161,8 +161,16 @@
     	var toSeconds = {|tempo, propotion| 60*propotion/tempo};
     	var totalDur = durations_.init.sum;
     	var durations = processDurations.(rotations, setUntilForDurs.(durations_.init, totalDur), totalDur)
-    	    .collect(_.durs)
-    	    .collect(_.collect(toSeconds.(data.baseTempo, _)));
+		.collect(_.durs)
+		.collect(_.collect(toSeconds.(data.baseTempo, _)))
+		.inject((scalingFactor: nil, durs: List []), {|acc, durs|
+			acc.scalingFactor = acc.scalingFactor.isNil.if(
+				cycle.isNil.if({1}, {cycle/durs.sum}),
+				{acc.scalingFactor}
+			);
+			acc.durs.add(durs*acc.scalingFactor);
+			acc
+		}).durs;
     	var canon = durations.collect({|voiceDurs, i|
     		(
     			notes: data.voices[i].transp+notes,
@@ -190,12 +198,12 @@
 	}
 
 	*diverge{
-		|symbol, melody, voices, tempos, baseTempo = 60, instruments, player, repeat = 1, osc, meta, convergeOnLast = false|
+		|symbol, melody, voices, tempos, baseTempo = 60, instruments, cycle, player, repeat = 1, osc, meta, convergeOnLast = false|
 		^try
 		{
 			if(voices.size != tempos.size,
 				{"Can.divergence requires that arguments \"voices\" and \"tempos\" to be arrays of the same size.".throw},
-				{this.prDiverge(symbol, melody, voices, tempos, baseTempo, instruments, player, repeat, osc, meta, convergeOnLast)}
+				{this.prDiverge(symbol, melody, voices, tempos, baseTempo, instruments, cycle, player, repeat, osc, meta, convergeOnLast)}
 			)
 		}
 		{_.error;}

--- a/Can/divergence.sc
+++ b/Can/divergence.sc
@@ -1,6 +1,6 @@
 +Can {
 	*prDiverge{
-		|symbol, melody, voices, tempos, baseTempo = 60, instruments, cycle, player, repeat, osc, meta, convergeOnLast = false|
+		|symbol, melody, voices, tempos, baseTempo = 60, instruments, period, player, repeat, osc, meta, convergeOnLast = false|
 
         var data = (
 			symbol: symbol,
@@ -165,7 +165,7 @@
 		.collect(_.collect(toSeconds.(data.baseTempo, _)))
 		.inject((scalingFactor: nil, durs: List []), {|acc, durs|
 			acc.scalingFactor = acc.scalingFactor.isNil.if(
-				cycle.isNil.if({1}, {cycle/durs.sum}),
+				period.isNil.if({1}, {period/durs.sum}),
 				{acc.scalingFactor}
 			);
 			acc.durs.add(durs*acc.scalingFactor);
@@ -198,12 +198,12 @@
 	}
 
 	*diverge{
-		|symbol, melody, voices, tempos, baseTempo = 60, instruments, cycle, player, repeat = 1, osc, meta, convergeOnLast = false|
+		|symbol, melody, voices, tempos, baseTempo = 60, instruments, period, player, repeat = 1, osc, meta, convergeOnLast = false|
 		^try
 		{
 			if(voices.size != tempos.size,
 				{"Can.divergence requires that arguments \"voices\" and \"tempos\" to be arrays of the same size.".throw},
-				{this.prDiverge(symbol, melody, voices, tempos, baseTempo, instruments, cycle, player, repeat, osc, meta, convergeOnLast)}
+				{this.prDiverge(symbol, melody, voices, tempos, baseTempo, instruments, period, player, repeat, osc, meta, convergeOnLast)}
 			)
 		}
 		{_.error;}


### PR DESCRIPTION
Allows the duration of a canon to be set via the `period` key

It is important to note that the values of the tempos, i.e. tempo = 60 will change when the canon is scaled up or down to fit the period, however the proportions between the tempos will remain the same.