### PR TITLE
Feature/transposition with functions

### DIFF
--- a/Can/convergence.sc
+++ b/Can/convergence.sc
@@ -6,12 +6,24 @@
 
         makeTempo = {|speed| 60/(speed/4)},
 
+		notes = melody.collect(_.note),// used on transposition when voice.transp.isFunction, not the most efficient implementation, because we go back to what Can.melody takes as input, but may do for now
+
         //creates voices [(melody: [(note, dur)], bcp)]
         voices1 = (voices
             .collect({|voice|
+				var voiceNotes = voice[\transp].isFunction.if(
+					{voice[\transp].(notes)}
+				);
                 //for each melody set the correct durations and transposition
-                melody.collect({|event|
-                    (dur: event.dur*makeTempo.(voice.tempo), note: event.note+voice.transp)
+                melody.collect({|event, i|
+					var note = voice[\transp].isFunction.if(
+						{voiceNotes[i]},
+						{event.note+voice.transp}
+					);
+                    (
+						dur: event.dur*makeTempo.(voice.tempo),
+						note: note
+					)
                 })
             })
             //get the durations of all notes Before the Convergence Point

--- a/Can/convergence.sc
+++ b/Can/convergence.sc
@@ -11,7 +11,7 @@
         //creates voices [(melody: [(note, dur)], bcp)]
         voices1 = (voices
             .collect({|voice|
-				var voiceNotes = voice[\transp].isFunction.if(
+                var voiceNotes = voice[\transp].isFunction.if(
                     {voice[\transp].(notes)}
                 );
                 //for each melody set the correct durations and transposition

--- a/Can/convergence.sc
+++ b/Can/convergence.sc
@@ -12,36 +12,36 @@
         voices1 = (voices
             .collect({|voice|
 				var voiceNotes = voice[\transp].isFunction.if(
-					{voice[\transp].(notes)}
-				);
+                    {voice[\transp].(notes)}
+                );
                 //for each melody set the correct durations and transposition
                 melody.collect({|event, i|
-					var note = voice[\transp].isFunction.if(
-						{voiceNotes[i]},
-						{event.note+voice.transp}
-					);
+                    var note = voice[\transp].isFunction.if(
+                        {voiceNotes[i]},
+                        {event.note+voice.transp}
+                    );
                     (
-						dur: event.dur*makeTempo.(voice.tempo),
-						note: note
-					)
+                        dur: event.dur*makeTempo.(voice.tempo),
+                        note: note
+                    )
                 })
-            })
+			})
             //get the durations of all notes Before the Convergence Point
             .collect({|voice|
                 var bcp = makeBcp.(cp, voice.collect(_.dur));
-			    (melody: voice, bcp: bcp)
+                (melody: voice, bcp: bcp)
             })
-        ),
+		),
 
 
         //sorted voices from longest to shortes
-    	//[(durs: [Float], notes: [midiNote], bcp: [Float])]
-        sortedBySpeed = (voices1.collect({|voice, i| (
-            durs: voice.melody.collect(_.dur),
-            notes: voice.melody.collect(_.note),
-            bcp: voice.bcp.sum,
+		//[(durs: [Float], notes: [midiNote], bcp: [Float])]
+		sortedBySpeed = (voices1.collect({|voice, i| (
+			durs: voice.melody.collect(_.dur),
+			notes: voice.melody.collect(_.note),
+			bcp: voice.bcp.sum,
 		    amp: voices1[i].amp
-        )})
+		)})
             .sort({|voice1, voice2| voice1.durs.sum > voice2.durs.sum })
         ),
 

--- a/Can/divergence.sc
+++ b/Can/divergence.sc
@@ -165,7 +165,10 @@
     	    .collect(_.collect(toSeconds.(data.baseTempo, _)));
     	var canon = durations.collect({|voiceDurs, i|
     		(
-    			notes: data.voices[i].transp+notes,
+				notes: data.voices[i][\transp].isFunction.if(
+					{data.voices[i][\transp].(notes)},
+					{data.voices[i].transp+notes}
+				),
 				durs: if(convergeOnLast, {voiceDurs++[durations_.last]}, {voiceDurs}),
     			onset: 0,
     			bcp: 0,


### PR DESCRIPTION
Allows `Can.converge` and `Can.diverge` to take functions, in addition to numbers, as elements of the `transps` array.

The function will receive the `notes` array and should return an array of notes.

```
Can.init
s.boot
(
var w = 6;
var c = Can.converge(
	instruments: [\sin],
	meta: (amp: 0.1),
	repeat: 1,
	cp: 3,
	melody: Can.melody(
		durs: [1,2,3,2]/4,
		notes: (60..68).scramble
	),
	voices: Can.convoices(
		60*[1,2,3, 4].scramble,
		[0, _.reverse,7, 12]
	)
);

c.visualize(s);
)

(
var w = 2;
var div = Can.diverge(
	instruments: [\sin],
	meta: (amp: 0.1),
	repeat: 1,
	melody: Can.melody(
		durs: [1,2,3,2]/4,
		notes: (60..68).scramble
	),
	voices: Can.divoices([1,_.reverse,3,4]),
	tempos: Can.divtempos(tempos:[1,2,3,4], percentageForTempo:[1,2,3,4], normalize: true),
);

div.visualize(s)
)
```