### PR TITLE
Multiple cps

### DIFF
--- a/Can/convergence.sc
+++ b/Can/convergence.sc
@@ -4,7 +4,7 @@
 		var
 		cp_ = cp.isFunction.if({cp.(melody)}, {cp}),
 
-		makeBcp = {|cp, line| line.copyRange(0, (cp - 2).asInteger)},
+		makeBcp = {|cp, line| line.copyRange(0, (cp - 2).asInteger).sum},
 
 		makeTempo = {|speed| 60/(speed/4)},
 
@@ -50,7 +50,7 @@
 			durs: voice.melody.collect(_.dur),
 			notes: voice.melody.collect(_.note),
 			amps: voice.melody.collect(_.amp),
-			bcp: voice.bcp.sum,
+			bcp: voice.bcp,
 			cp: voice.cp
 		)})
 		.sort({|voice1, voice2| voice1.durs.sum > voice2.durs.sum })

--- a/Can/convergence.sc
+++ b/Can/convergence.sc
@@ -65,7 +65,7 @@
 				remainder: sortedBySpeed[0].durs.sum - (onset + voice.durs.sum),
 				bcp: voice.bcp,
 				onset: onset,
-				cp: cp_
+				cp: voice.cp
 			)
 		}),
 

--- a/Can/convergence.sc
+++ b/Can/convergence.sc
@@ -37,8 +37,9 @@
 			})
 			//get the durations of all notes Before the Convergence Point
 			.collect({|voice, i|
-				var bcp = makeBcp.(cp_, voice.collect(_.dur));
-				(melody: voice, bcp: bcp)
+				var cp = if(cp_.isArray, {cp_.wrapAt(i)}, {cp_});
+				var bcp = makeBcp.(cp, voice.collect(_.dur));
+				(melody: voice, bcp: bcp, cp: cp)
 			})
 		),
 
@@ -50,17 +51,13 @@
 			notes: voice.melody.collect(_.note),
 			amps: voice.melody.collect(_.amp),
 			bcp: voice.bcp.sum,
+			cp: voice.cp
 		)})
 		.sort({|voice1, voice2| voice1.durs.sum > voice2.durs.sum })
 		),
 
-		//voice onset times
-		onsets = sortedBySpeed.reverse.inject([], {|acc, elem|
-			acc ++ [(sortedBySpeed[0].bcp - elem.bcp).abs];
-		}),
-
 		canon = sortedBySpeed.collect({|voice, i|
-			var onset = (sortedBySpeed[0].bcp - voice.bcp).abs;
+			var onset = (sortedBySpeed[0].durs.copyRange(0, voice.cp -2 ).sum - voice.bcp).abs;
 			(
 				durs: voice.durs,
 				notes: voice.notes,

--- a/Can/helpers.sc
+++ b/Can/helpers.sc
@@ -1,39 +1,45 @@
 +Can {
-	//melody :: ([Float], [Float]) -> [(dur, note)]
-	*melody {|durs, notes|
+	*prGetAmp {|amps, i|
+		^if(
+			amps.isArray && amps.size > 0,
+			{amps.wrapAt(i)},
+			{1})
+	}
+	//melody :: ([Float], [Float], [Float]) -> [(dur, note, amp)]
+	*melody {|durs, notes, amps = ([1])|
 		^[durs.size, notes.size].minItem.collect({|i|
-			(dur: durs[i], note: notes[i])
+			(dur: durs[i], note: notes[i], amp: Can.prGetAmp(amps, i))
 		})
 	}
-	//isomelody ::([Float], [Float], Int) -> [(dur, note)]
-	*isomelody {|durs, notes, len|
+	//isomelody ::([Float], [Float], [Float], Int) -> [(dur, note, amp)]
+	*isomelody {|durs, notes, amps = ([1]), len|
 		var len_ = len ? max(durs.size, notes.size);
 		^len_.collect({|i|
-			(dur: durs.wrapAt(i), note: notes.wrapAt(i))
+			(dur: durs.wrapAt(i), note: notes.wrapAt(i), amp: Can.prGetAmp(amps, i))
 		});
 	}
 
 	//convvoices :: ([Float], [Float], [Float]) -> [(tempo, transp, amp)]
-	*convoices { | tempos, transps, amps = ([])|
+	*convoices { | tempos, transps, amps = ([1])|
 		^[tempos.size, transps.size].minItem.collect({|i|
-			(tempo: tempos[i], transp: transps[i], amp: amps[i] ? 1)
+			(tempo: tempos[i], transp: transps[i], amp: Can.prGetAmp(amps, i))
 		})
 	}
 
 	//divoices :: ([Float], [Float]) ->[(transp: Float, amp: Float)]
-	*divoices { |transps, amps = ([])|
+	*divoices { |transps, amps = ([1])|
 		^transps.collect({|transp, i|
-			(transp: transp, amp: amps[i] ? 1)
+			(transp: transp, amp: Can.prGetAmp(amps, i))
 		})
 	}
 
 	//divtempos :: ([Float], [Float], Boolean) ->[(tempo: Float, percentage: Float)]
 	*divtempos { | tempos, percentageForTempo, normalize= true|
-        var min = [tempos.size, percentageForTempo.size].minItem;
+		var min = [tempos.size, percentageForTempo.size].minItem;
 
-        var percentages = if(normalize, {percentageForTempo[0..min - 1].normalizeSum*100}, {percentageForTempo[0..min - 1]});
+		var percentages = if(normalize, {percentageForTempo[0..min - 1].normalizeSum*100}, {percentageForTempo[0..min - 1]});
 
-		^min.postln.collect({|i|
+		^min.collect({|i|
 			(tempo: tempos[i], percentage: percentages[i])
 		});
 	}
@@ -53,5 +59,3 @@
 		)
 	}
 }
-
-

--- a/Can/pPlayer.sc
+++ b/Can/pPlayer.sc
@@ -25,9 +25,9 @@
 				var pairs = [
 					\instrument, instrument.wrapAt(index),
 					\dur, Pseq([voice.onset] ++ voice.durs ++ [voice.remainder], repeat),
-					\midinote, Pseq([\rest] ++ voice.notes ++ [\rest], inf),
+					\midinote, Pseq([\rest] ++ voice.notes ++ [\rest], repeat),
 					\out, out,
-					\amp, Pseq(gain * ([0]++voice.amps++[0])),
+					\amp, Pseq(gain * ([0]++voice.amps++[0]), repeat),
 					\pan, pan
 				]
 				++oscParam.(index, voice.cp)


### PR DESCRIPTION
Adds support for multiple convergence points. If there are more voices than cps, `.wrapAt` is used.

```
Can.init
s.boot
(
c = Can.converge(
	instruments: [\sin],
	meta: (gain: 1),
	repeat: 1,
    cp: [1, 2, 4, 5],
	melody: Can.isomelody(
		durs: [1,1,2,1],
		notes: (60..63).scramble,
		amps: [0.4, 0.2, 1]
	),
	voices: Can.convoices(
		(60..65),
		(0..4),
		[0.7, 0.3, 0.5]
	)
);
c.visualize(s, false);
)
```